### PR TITLE
minor: update starship prompt

### DIFF
--- a/.config/starship/starship.toml
+++ b/.config/starship/starship.toml
@@ -1,23 +1,25 @@
+"$schema" = "https://starship.rs/config-schema.json"
+
 add_newline = false
 
 format = """\
 $shell\
 $git_branch\
 $git_status\
-$java\
-$python\
+$git_state\
 $directory\
-[❯](bold green)"""
+$character"""
 
 [character]
+format = "$symbol"
 success_symbol = "[❯](bold green)"
-error_symbol = "[✗](bold red)"
+error_symbol = "[❯](bold red)"
 
 [shell]
 disabled = false
-fish_indicator = "[](bold yellow)"
-zsh_indicator = "[⚡](purple)"
+fish_indicator = "[󰈺](bold yellow)"
+zsh_indicator = "[󱐋](purple)"
+powershell_indicator = "[󰚥](bold blue)"
 
 [directory]
-format = "[$path]($style)[$read_only]($read_only_style)"
-
+format = "[$path]($style)$read_only"


### PR DESCRIPTION
Made some changes:
- added starship schema (for IDE support)
- removed programming language modules
- updated character module config to remove space at the end through the `format` option (this was why I wasn't using the character module previously)
- updated character module to use the same icon for success and error (just with a different color)
- updated shell icons to use new nerd font icons
- removed read-only style from directory module config
  - this sets the read-only icon to red, but the default icon (the padlock) doesn't change color anyway with the font I use, and I don't want it to be red even if it did