### PR TITLE
minor: add kube module to starship config

### DIFF
--- a/.config/starship/starship.toml
+++ b/.config/starship/starship.toml
@@ -4,16 +4,12 @@ add_newline = false
 
 format = """\
 $shell\
+$kubernetes\
 $git_branch\
 $git_status\
 $git_state\
 $directory\
 $character"""
-
-[character]
-format = "$symbol"
-success_symbol = "[❯](bold green)"
-error_symbol = "[❯](bold red)"
 
 [shell]
 disabled = false
@@ -21,5 +17,20 @@ fish_indicator = "[󰈺](bold yellow)"
 zsh_indicator = "[󱐋](purple)"
 powershell_indicator = "[󰚥](bold blue)"
 
+[kubernetes]
+disabled = false
+symbol = "󱃾"
+style = "bold blue"
+format = "[$symbol $context]($style) "
+
+[git_branch]
+symbol = ""
+format = "[$symbol $branch]($style) "
+
 [directory]
 format = "[$path]($style)$read_only"
+
+[character]
+format = "$symbol"
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"


### PR DESCRIPTION
Added the kubernetes module to my starship config. Also re-ordered the module configs to be in the same order they appear in the prompt. Additionally, set the git branch format option so the word "on" does not appear (as in the default format).