### PR TITLE
minor: change zsh history options

### DIFF
--- a/.config/zsh/config/history.zsh
+++ b/.config/zsh/config/history.zsh
@@ -4,6 +4,8 @@ HISTSIZE=10000
 SAVEHIST=10000
 
 # History settings
-setopt appendhistory # append to history instead of overwriting at the end of every session
-setopt sharehistory # share history with other terminal sessions
-setopt histignorealldups # ignore duplicate entries in history
+setopt share_history # share history with other terminal sessions
+setopt hist_ignore_all_dups # ignore duplicate entries in history (in memory)
+setopt hist_save_no_dups # don't save duplicate entries in history (in file)
+setopt hist_reduce_blanks # remove extra blanks from history entries
+setopt hist_verify # show command before executing when using history expansion


### PR DESCRIPTION
Per https://github.com/neilwiborg/dotfiles/issues/12, my history settings should be improved.

I have tested these settings and validated that history is shared (the terminal sessions appear to read from the `$HISTFILE` after every command, so if you run `foo` in terminal A then it won't appear in terminal B's command history until you run another command, say `bar`, in terminal B).

I have also validated that I get re-prompted to run a command if I use `!!` with the actual command substituted.

I have also verified that duplicate history entries do not appear in the in-memory command history. There's a quirk with the `$HISTFILE` where duplicates do get written because commands are getting written with a timestamp, even though `extended_history` is not turned on. Interestingly the duplicates get removed the next time I `reload` my shell.